### PR TITLE
Documentation and Snippets Update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ You can contribute in many ways:
 Types of Contributions
 --
 #### Report Bugs
-Report bugs at https://github.com/PaloAltoNetworks/pandevice/issues.
+Report bugs at https://github.com/PaloAltoNetworks/iron-skillet/issues.
 
 If you are reporting a bug, please include:
 
@@ -34,30 +34,3 @@ If you are proposing a change:
 * Explain in detail why it is needed.
 * Keep the scope as narrow as possible, to make it easier to implement.
 * Remember that this is a volunteer-driven project and that contributions are welcome :)
-
-Get Started!
-------------
-
-Ready to contribute? Here's how to set up `iron-skillet` for local development.
-
-1. Fork the `iron-skillet` repo on GitHub.
-2. Clone your fork locally.
-
-    `$ git clone git@github.com:your_name_here/iron-skillet.git
-   $ cd iron-skillet`
-
-3. Create a branch for local development.
-
-    `$ git checkout -b name-of-your-branch`
-
-4. Edit the XML configuration snippets locally.  An XML editor is recommended to ensure proper XML structure.
-
-5. Import the XML configuration snippet into a non-production NGFW, load it into the candidate configuration, and ensure that the candidate configuration commits without errors.
-
-6. Commit your changes and push your branch to GitHub::
-
-    `$ git add .
-   $ git commit -m "Your detailed description of your changes."
-   $ git push origin name-of-your-branch`
-
-7. Submit a pull request through the GitHub website.

--- a/panos_v10.0/panorama/panorama_device_setting_10_0.skillet.yaml
+++ b/panos_v10.0/panorama/panorama_device_setting_10_0.skillet.yaml
@@ -27,6 +27,55 @@ snippets:
         <udp-bypass-exceed-queue>no</udp-bypass-exceed-queue>
       </ctd>
 
+-   name: ironskillet_device_setting_high_dp_load
+    xpath: /config/devices/entry[@name='localhost.localdomain']/template/entry[@name='iron-skillet']/config/devices/entry[@name='localhost.localdomain']/deviceconfig/setting
+    element: |-
+      <management>
+        <enable-log-high-dp-load>yes</enable-log-high-dp-load>
+      </management>
+
+-   name: ironskillet_device_setting_max_csv
+    xpath: /config/devices/entry[@name='localhost.localdomain']/template/entry[@name='iron-skillet']/config/devices/entry[@name='localhost.localdomain']/deviceconfig/setting
+    element: |-
+      <management>
+        <max-rows-in-csv-export>1048576</max-rows-in-csv-export>
+      </management>
+
+-   name: ironskillet_device_setting_api_key_lifetime
+    xpath: /config/devices/entry[@name='localhost.localdomain']/template/entry[@name='iron-skillet']/config/devices/entry[@name='localhost.localdomain']/deviceconfig/setting
+    element: |-
+      <management>
+        <api>
+          <key>
+            <lifetime>{{ API_KEY_LIFETIME }}</lifetime>
+          </key>
+        </api>
+      </management>
+
+-   name: ironskillet_device_setting_admin_lockout
+    xpath: /config/devices/entry[@name='localhost.localdomain']/template/entry[@name='iron-skillet']/config/devices/entry[@name='localhost.localdomain']/deviceconfig/setting
+    element: |-
+      <management>
+        <admin-lockout>
+          <failed-attempts>5</failed-attempts>
+          <lockout-time>30</lockout-time>
+        </admin-lockout>
+      </management>
+
+-   name: ironskillet_device_setting_idle_timeout
+    xpath: /config/devices/entry[@name='localhost.localdomain']/template/entry[@name='iron-skillet']/config/devices/entry[@name='localhost.localdomain']/deviceconfig/setting
+    element: |-
+      <management>
+        <idle-timeout>10</idle-timeout>
+      </management>
+
+-   name: ironskillet_device_setting_commit_lock
+    xpath: /config/devices/entry[@name='localhost.localdomain']/template/entry[@name='iron-skillet']/config/devices/entry[@name='localhost.localdomain']/deviceconfig/setting
+    element: |-
+      <management>
+        <auto-acquire-commit-lock>yes</auto-acquire-commit-lock>
+      </management>
+
 -   name: ironskillet_device_setting_management
     xpath: /config/devices/entry[@name='localhost.localdomain']/template/entry[@name='iron-skillet']/config/devices/entry[@name='localhost.localdomain']/deviceconfig/setting
     element: |-


### PR DESCRIPTION
## Description

Updated the links in the Contributing.md file to point to the correct IronSkillet issues board. Also removed the redundant Get Started section.

Updated missing snippets in the 10.0 folder of ironskillet-components. Specifically added snippets ending in [high_dp_load, max_csv, api_key_lifetime, admin_lockout, idle_timeout, and commit_lock] to the panorama_device_setting_10_0.skillet.yaml file.

## Motivation and Context

Fixes skillet loader errors that come up when trying to run the "sli load" command in the IronSkillet 10.0 repo. Allows for Sli tooling to be used instead of the python code tooling directory.

## How Has This Been Tested?

Ran sli load on my local machine after these changes were made and no loader errors came up.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
