### PR TITLE
Removed WhiteSpace around {{STACK}} Bug Fix

### DIFF
--- a/panos_v10.0/panorama/panorama_template_stack_10_0.skillet.yaml
+++ b/panos_v10.0/panorama/panorama_template_stack_10_0.skillet.yaml
@@ -22,7 +22,7 @@ snippets:
 -   name: ironskillet_template_stack
     xpath: /config/devices/entry[@name='localhost.localdomain']/template-stack
     element: |-
-      <entry name="{{ STACK }}">
+      <entry name="{{STACK}}">
         <templates>
           <member>iron-skillet</member>
         </templates>


### PR DESCRIPTION
## Description

Removed possible troublesome whitespace around the {{STACK}} variable for better SLI functionality.

## Motivation and Context

Should help fix a sli template bug.

## How Has This Been Tested?

Tested changes in my local cloned repo.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
