### PR TITLE
BPA Recommendation Value Fix

### DIFF
--- a/panos_v10.0/ngfw/panos_ngfw_device_setting_10_0.skillet.yaml
+++ b/panos_v10.0/ngfw/panos_ngfw_device_setting_10_0.skillet.yaml
@@ -79,7 +79,7 @@ snippets:
             <size-limit>50</size-limit>
           </entry>
           <entry name="script">
-            <size-limit>2000</size-limit>
+            <size-limit>20</size-limit>
           </entry>
          </file-size-limit>
         <report-benign-file>yes</report-benign-file>

--- a/panos_v10.0/panorama/panorama_device_setting_10_0.skillet.yaml
+++ b/panos_v10.0/panorama/panorama_device_setting_10_0.skillet.yaml
@@ -128,7 +128,7 @@ snippets:
             <size-limit>50</size-limit>
           </entry>
           <entry name="script">
-            <size-limit>2000</size-limit>
+            <size-limit>20</size-limit>
           </entry>
          </file-size-limit>
         <report-benign-file>yes</report-benign-file>

--- a/panos_v10.1/ngfw/panos_ngfw_device_setting_10_1.skillet.yaml
+++ b/panos_v10.1/ngfw/panos_ngfw_device_setting_10_1.skillet.yaml
@@ -109,7 +109,7 @@ snippets:
             <size-limit>50</size-limit>
           </entry>
           <entry name="script">
-            <size-limit>2000</size-limit>
+            <size-limit>20</size-limit>
           </entry>
          </file-size-limit>
         <report-benign-file>yes</report-benign-file>

--- a/panos_v10.1/panorama/panorama_device_setting_10_1.skillet.yaml
+++ b/panos_v10.1/panorama/panorama_device_setting_10_1.skillet.yaml
@@ -109,7 +109,7 @@ snippets:
             <size-limit>50</size-limit>
           </entry>
           <entry name="script">
-            <size-limit>2000</size-limit>
+            <size-limit>20</size-limit>
           </entry>
          </file-size-limit>
         <report-benign-file>yes</report-benign-file>


### PR DESCRIPTION
## Description

Updated script file size from 2000 to 20KB as per BPA team and online NGFW best Practice recommendations. Updates were made in both the NGFW and Panorama device settings snippets for both 10.0 and 10.1.

